### PR TITLE
feat: 리뷰 평균 별점 추가 및 체험 참가, 북마크 중복 에러 핸들링

### DIFF
--- a/src/main/java/com/wageul/wageul_server/bookmark/repository/BookmarkJpaRepository.java
+++ b/src/main/java/com/wageul/wageul_server/bookmark/repository/BookmarkJpaRepository.java
@@ -3,4 +3,5 @@ package com.wageul.wageul_server.bookmark.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookmarkJpaRepository extends JpaRepository<BookmarkEntity, Long> {
+	Long countByUserIdAndExperienceId(long userId, long experienceId);
 }

--- a/src/main/java/com/wageul/wageul_server/bookmark/repository/BookmarkRepositoryImpl.java
+++ b/src/main/java/com/wageul/wageul_server/bookmark/repository/BookmarkRepositoryImpl.java
@@ -21,6 +21,11 @@ public class BookmarkRepositoryImpl extends BookmarkCustomRepositoryImpl impleme
 	}
 
 	@Override
+	public Long countByUserIdAndExperienceId(long userId, long experienceId) {
+		return bookmarkJpaRepository.countByUserIdAndExperienceId(userId, experienceId);
+	}
+
+	@Override
 	public void delete(Bookmark bookmark) {
 		bookmarkJpaRepository.delete(BookmarkEntity.from(bookmark));
 	}

--- a/src/main/java/com/wageul/wageul_server/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/wageul/wageul_server/bookmark/service/BookmarkService.java
@@ -31,6 +31,11 @@ public class BookmarkService {
 			.orElseThrow(() -> new RuntimeException("NO LOGIN USER INFO"));
 		Experience experience = experienceRepository.findById(experienceId)
 			.orElseThrow(() -> new RuntimeException("NO EXPERIENCE"));
+
+		if (bookmarkRepository.countByUserIdAndExperienceId(loginUser.getId(), experienceId) > 0) {
+			throw new RuntimeException("ALREADY BOOKMARKED");
+		}
+
 		Bookmark bookmark = Bookmark.builder()
 			.user(loginUser)
 			.experience(experience)

--- a/src/main/java/com/wageul/wageul_server/bookmark/service/port/BookmarkRepository.java
+++ b/src/main/java/com/wageul/wageul_server/bookmark/service/port/BookmarkRepository.java
@@ -8,5 +8,6 @@ import com.wageul.wageul_server.user.domain.User;
 public interface BookmarkRepository extends BookmarkCustomRepository {
 	Bookmark save(Bookmark bookmark);
 
+	Long countByUserIdAndExperienceId(long userId, long experienceId);
 	void delete(Bookmark bookmark);
 }

--- a/src/main/java/com/wageul/wageul_server/participation/repository/ParticipationCustomRepository.java
+++ b/src/main/java/com/wageul/wageul_server/participation/repository/ParticipationCustomRepository.java
@@ -1,6 +1,7 @@
 package com.wageul.wageul_server.participation.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.wageul.wageul_server.experience.domain.Experience;
 import com.wageul.wageul_server.participation.domain.Participation;

--- a/src/main/java/com/wageul/wageul_server/participation/repository/ParticipationCustomRepositoryImpl.java
+++ b/src/main/java/com/wageul/wageul_server/participation/repository/ParticipationCustomRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.wageul.wageul_server.participation.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 

--- a/src/main/java/com/wageul/wageul_server/participation/repository/ParticipationJpaRepository.java
+++ b/src/main/java/com/wageul/wageul_server/participation/repository/ParticipationJpaRepository.java
@@ -3,4 +3,5 @@ package com.wageul.wageul_server.participation.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ParticipationJpaRepository extends JpaRepository<ParticipationEntity, Long>, ParticipationCustomRepository {
+	Long countByUserIdAndExperienceId(long userId, long experienceId);
 }

--- a/src/main/java/com/wageul/wageul_server/participation/repository/ParticipationRepositoryImpl.java
+++ b/src/main/java/com/wageul/wageul_server/participation/repository/ParticipationRepositoryImpl.java
@@ -32,6 +32,11 @@ public class ParticipationRepositoryImpl extends ParticipationCustomRepositoryIm
 	}
 
 	@Override
+	public Long countByUserIdAndExperienceId(long userId, long experienceId) {
+		return participationJpaRepository.countByUserIdAndExperienceId(userId, experienceId);
+	}
+
+	@Override
 	public void delete(Participation participation) {
 		participationJpaRepository.delete(ParticipationEntity.from(participation));
 	}

--- a/src/main/java/com/wageul/wageul_server/participation/service/ParticipationService.java
+++ b/src/main/java/com/wageul/wageul_server/participation/service/ParticipationService.java
@@ -28,11 +28,17 @@ public class ParticipationService {
 	public Participation create(ParticipationCreate participationCreate) {
 		User user = userRepository.findById(authorizationUtil.getLoginUserId()).orElse(null);
 		Experience experience = experienceRepository.findById(participationCreate.getExperienceId()).orElse(null);
-		if (user != null && experience != null) {
-			Participation participation = Participation.from(user, experience);
-			return participationRepository.save(participation);
+
+		if (user == null || experience == null) {
+			throw new RuntimeException("NO USER OR EXPERIENCE");
 		}
-		return null;
+		if (participationRepository.countByUserIdAndExperienceId(user.getId(), experience.getId()) > 0) {
+			// 이미 참여 정보가 있음
+			throw new RuntimeException("ALREADY PARTICIPATE");
+		}
+
+		Participation participation = Participation.from(user, experience);
+		return participationRepository.save(participation);
 	}
 
 	@Transactional

--- a/src/main/java/com/wageul/wageul_server/participation/service/port/ParticipationRepository.java
+++ b/src/main/java/com/wageul/wageul_server/participation/service/port/ParticipationRepository.java
@@ -14,5 +14,7 @@ public interface ParticipationRepository extends ParticipationCustomRepository {
 
 	Participation save(Participation participation);
 
+	Long countByUserIdAndExperienceId(long userId, long experienceId);
+
 	void delete(Participation participation);
 }

--- a/src/main/java/com/wageul/wageul_server/review/controller/ReviewController.java
+++ b/src/main/java/com/wageul/wageul_server/review/controller/ReviewController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.wageul.wageul_server.review.domain.Review;
 import com.wageul.wageul_server.review.dto.ReviewCreate;
+import com.wageul.wageul_server.review.dto.ReviewRateResponse;
 import com.wageul.wageul_server.review.dto.ReviewResponse;
 import com.wageul.wageul_server.review.service.ReviewService;
 
@@ -39,11 +40,9 @@ public class ReviewController {
 	}
 
 	@GetMapping("/user/{userId}")
-	public ResponseEntity<List<ReviewResponse>> getUserReviews(@PathVariable("userId") Long userId) {
-		List<Review> reviews = reviewService.getAllByTarget(userId);
+	public ResponseEntity<ReviewRateResponse> getUserReviews(@PathVariable("userId") Long userId) {
+		ReviewRateResponse reviewRateResponse = reviewService.getAllByTarget(userId);
 
-		List<ReviewResponse> reviewResponses = reviews.stream().map(ReviewResponse::new).toList();
-
-		return ResponseEntity.ok().body(reviewResponses);
+		return ResponseEntity.ok().body(reviewRateResponse);
 	}
 }

--- a/src/main/java/com/wageul/wageul_server/review/dto/ReviewRateResponse.java
+++ b/src/main/java/com/wageul/wageul_server/review/dto/ReviewRateResponse.java
@@ -1,0 +1,19 @@
+package com.wageul.wageul_server.review.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ReviewRateResponse {
+
+	private final Double avg;
+	private final List<ReviewResponse> reviews;
+
+	@Builder
+	public ReviewRateResponse(Double avg, List<ReviewResponse> reviewResponse) {
+		this.avg = avg;
+		this.reviews = reviewResponse;
+	}
+}

--- a/src/main/java/com/wageul/wageul_server/review/service/ReviewService.java
+++ b/src/main/java/com/wageul/wageul_server/review/service/ReviewService.java
@@ -8,6 +8,8 @@ import org.springframework.transaction.annotation.Transactional;
 import com.wageul.wageul_server.oauth2.AuthorizationUtil;
 import com.wageul.wageul_server.review.domain.Review;
 import com.wageul.wageul_server.review.dto.ReviewCreate;
+import com.wageul.wageul_server.review.dto.ReviewRateResponse;
+import com.wageul.wageul_server.review.dto.ReviewResponse;
 import com.wageul.wageul_server.review.service.port.ReviewRepository;
 import com.wageul.wageul_server.user.domain.User;
 import com.wageul.wageul_server.user.service.port.UserRepository;
@@ -46,9 +48,20 @@ public class ReviewService {
 	}
 
 	@Transactional
-	public List<Review> getAllByTarget(Long userId) {
+	public ReviewRateResponse getAllByTarget(Long userId) {
 		User target = userRepository.findById(userId)
 			.orElseThrow(() -> new RuntimeException("NO REVIEW TARGET INFO"));
-		return reviewRepository.findByTarget(target);
+
+		List<Review> reviews = reviewRepository.findByTarget(target);
+
+		List<ReviewResponse> reviewResponses = reviews.stream().map(ReviewResponse::new).toList();
+
+		Double sum = 0D;
+		for (Review review : reviews) {
+			sum += review.getRate();
+		}
+		Double avg = sum / reviews.size();
+
+		return new ReviewRateResponse(avg, reviewResponses);
 	}
 }

--- a/src/test/java/com/wageul/wageul_server/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/com/wageul/wageul_server/bookmark/service/BookmarkServiceTest.java
@@ -66,6 +66,34 @@ class BookmarkServiceTest {
 	}
 
 	@Test
+	void 북마크추가는_한번만가능() {
+		// given
+		User user = User.builder()
+			.id(userId)
+			.email("abc@gmail.com")
+			.name("test")
+			.build();
+
+		userRepository.save(user);
+
+		Experience experience = Experience.builder()
+			.id(1L)
+			.title("experience!")
+			.content("new experience")
+			.build();
+
+		experienceRepository.save(experience);
+
+		// when
+		Bookmark bookmark = bookmarkService.create(experience.getId());
+
+		// then
+		Assertions.assertThatThrownBy(() ->
+			bookmarkService.create(experience.getId())
+		).hasMessage("ALREADY BOOKMARKED");
+	}
+
+	@Test
 	void 북마크삭제() {
 		// given
 		User user = User.builder()

--- a/src/test/java/com/wageul/wageul_server/mock/FakeBookmarkRepository.java
+++ b/src/test/java/com/wageul/wageul_server/mock/FakeBookmarkRepository.java
@@ -51,6 +51,15 @@ public class FakeBookmarkRepository implements BookmarkRepository {
 	}
 
 	@Override
+	public Long countByUserIdAndExperienceId(long userId, long experienceId) {
+		return (long) data
+			.stream()
+			.map(item -> item.getUser().getId() == userId && item.getExperience().getId() == experienceId)
+			.toList()
+			.size();
+	}
+
+	@Override
 	public void delete(Bookmark bookmark) {
 		data.removeIf(item -> item.equals(bookmark));
 	}

--- a/src/test/java/com/wageul/wageul_server/mock/FakeParticipationRepository.java
+++ b/src/test/java/com/wageul/wageul_server/mock/FakeParticipationRepository.java
@@ -45,6 +45,15 @@ public class FakeParticipationRepository implements ParticipationRepository {
 	}
 
 	@Override
+	public Long countByUserIdAndExperienceId(long userId, long experienceId) {
+		return (long) data
+			.stream()
+			.map(item -> item.getUser().getId() == userId && item.getExperience().getId() == experienceId)
+			.toList()
+			.size();
+	}
+
+	@Override
 	public void delete(Participation participation) {
 		data.removeIf(item -> Objects.equals(item.getId(), participation.getId()));
 	}

--- a/src/test/java/com/wageul/wageul_server/participation/service/ParticipationServiceTest.java
+++ b/src/test/java/com/wageul/wageul_server/participation/service/ParticipationServiceTest.java
@@ -69,6 +69,38 @@ class ParticipationServiceTest {
 	}
 
 	@Test
+	void 체험신청은_두번할수없다() {
+		// given
+		User user = User.builder()
+			.id(1L)
+			.email("abc@gmail.com")
+			.name("test")
+			.build();
+
+		fakeUserRepository.save(user);
+
+		Experience experience = Experience.builder()
+			.id(1L)
+			.title("experience!")
+			.content("new experience")
+			.build();
+
+		fakeExperienceRepository.save(experience);
+
+		ParticipationCreate participationCreate = ParticipationCreate.builder()
+			.experienceId(experience.getId())
+			.build();
+
+		// when
+		Participation participation = participationService.create(participationCreate);
+
+		// then
+		Assertions.assertThatThrownBy(() ->
+			participationService.create(participationCreate)
+		).hasMessage("ALREADY PARTICIPATE");
+	}
+
+	@Test
 	void 체험신청취소() {
 		// given
 		User user = User.builder()

--- a/src/test/java/com/wageul/wageul_server/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/wageul/wageul_server/review/service/ReviewServiceTest.java
@@ -13,6 +13,7 @@ import com.wageul.wageul_server.mock.FakeReviewRepository;
 import com.wageul.wageul_server.mock.FakeUserRepository;
 import com.wageul.wageul_server.review.domain.Review;
 import com.wageul.wageul_server.review.dto.ReviewCreate;
+import com.wageul.wageul_server.review.dto.ReviewRateResponse;
 import com.wageul.wageul_server.user.domain.User;
 
 class ReviewServiceTest {
@@ -90,7 +91,7 @@ class ReviewServiceTest {
 		reviewService.delete(review.getId());
 
 		// then
-		Assertions.assertThat(reviewService.getAllByTarget(user2.getId()).size()).isEqualTo(0);
+		Assertions.assertThat(reviewService.getAllByTarget(user2.getId()).getReviews().size()).isEqualTo(0);
 	}
 
 	@Test
@@ -161,13 +162,14 @@ class ReviewServiceTest {
 		Review review2 = reviewService.create(reviewCreate2);
 
 		// when
-		List<Review> reviews = reviewService.getAllByTarget(user2.getId());
+		ReviewRateResponse reviewRateResponse = reviewService.getAllByTarget(user2.getId());
 
 		// then
-		Assertions.assertThat(reviews.size()).isEqualTo(2);
-		Assertions.assertThat(reviews.get(0).getContent()).isEqualTo("this is review");
-		Assertions.assertThat(reviews.get(0).getRate()).isEqualTo(5);
-		Assertions.assertThat(reviews.get(1).getContent()).isEqualTo("this is another review");
-		Assertions.assertThat(reviews.get(1).getRate()).isEqualTo(3);
+		Assertions.assertThat(reviewRateResponse.getAvg()).isEqualTo(4);
+		Assertions.assertThat(reviewRateResponse.getReviews().size()).isEqualTo(2);
+		Assertions.assertThat(reviewRateResponse.getReviews().get(0).getContent()).isEqualTo("this is review");
+		Assertions.assertThat(reviewRateResponse.getReviews().get(0).getRate()).isEqualTo(5);
+		Assertions.assertThat(reviewRateResponse.getReviews().get(1).getContent()).isEqualTo("this is another review");
+		Assertions.assertThat(reviewRateResponse.getReviews().get(1).getRate()).isEqualTo(3);
 	}
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #48

## 📌 작업 내용 및 특이사항
- 리뷰 조회 시 평균 별점 추가적으로 계산해서 응답
- 체험 참가, 북마크 중복 에러 핸들링

## 📝 참고사항
- `Long countByUserIdAndExperienceId(long userId, long experienceId);` 와 같이 JpaRepository에서 구현

## 📚 기타
- 
